### PR TITLE
Correct reply to vMustReplyEmpty

### DIFF
--- a/src/GdbServer.cpp
+++ b/src/GdbServer.cpp
@@ -938,7 +938,7 @@ GdbServer::rspVpkt ()
     {
       cerr << "Warning: Unknown RSP 'v' packet type " << pkt->data
 	   << ": ignored" << endl;
-      pkt->packStr ("E01");
+      pkt->packStr ("");
       rsp->putPkt (pkt);
       return;
     }


### PR DESCRIPTION
Modern versions of gdb require an empty string response to a vMustReplyEmpty packet.  This patch changes the proxy to emit "" instead of "E01" in case of an unknown packet type.