### PR TITLE
Remove "Closing client connection: " from error log

### DIFF
--- a/src/RspConnection.cpp
+++ b/src/RspConnection.cpp
@@ -468,7 +468,6 @@ RspConnection::putRspChar (char  c)
 	  if ((EAGAIN != errno) && (EINTR != errno))
 	    {
 	      cerr << "Warning: Failed to write to RSP client: "
-			<< "Closing client connection: "
 			<<  strerror (errno) << endl;
 	      return  false;
 	    }
@@ -516,7 +515,6 @@ RspConnection::getRspChar ()
 	  if (EINTR != errno)
 	    {
 	      cerr << "Warning: Failed to read from RSP client: "
-		   << "Closing client connection: "
 		   <<  strerror (errno) << endl;
 	      return  -1;
 	    }


### PR DESCRIPTION
since clientFd isn't closed in this failure case
