### PR TITLE
Minor fix for SimProc

### DIFF
--- a/src/SimProc.cpp
+++ b/src/SimProc.cpp
@@ -167,7 +167,7 @@ SimProc::getNumRegs ()
 bool
 SimProc::isValidReg (int  regNum)
 {
-  return  (0 <= regNum) && (regNum <= numRegs);
+  return  (0 <= regNum) && (regNum < numRegs);
 
 }	// isValidReg ()
 

--- a/src/SimProc.cpp
+++ b/src/SimProc.cpp
@@ -352,6 +352,7 @@ SimProc::parse ()
   parseErrorCount   = 0;
 
   ch     = -1;				// Init the char reader
+  prevCh = -1;
   nextCh = -1;				// No call to unreadChar () yet
   readChar ();
 
@@ -1910,6 +1911,7 @@ SimProc::unreadChar ()
     {
       nextCh = ch;			// Save to use again
       ch     = prevCh;			// Restore old ch
+      prevCh = -1;
     }
 
   if ('\n' == nextCh)			// Reduce the line number count

--- a/src/SimProc.cpp
+++ b/src/SimProc.cpp
@@ -1531,7 +1531,7 @@ SimProc::extractNumberLval ()
 	  return;
 	  
 	case 'b':
-	  numberLval = str2base (2, 1);
+	  numberLval = str2base (2, 2);
 	  return;
 	  
 	default:

--- a/src/SimProc.cpp
+++ b/src/SimProc.cpp
@@ -1353,6 +1353,7 @@ SimProc::parseWarning (const char *format,
 
   va_start (args, format);
   parseMessage ("Warning: ", format, args);
+  va_end (args);
 
   parseWarningCount++;
 
@@ -1373,6 +1374,7 @@ SimProc::parseError (const char *format,
 
   va_start (args, format);
   parseMessage ("ERROR: ", format, args);
+  va_end (args);
 
   parseErrorCount++;
 
@@ -1392,13 +1394,11 @@ SimProc::parseError (const char *format,
 void
 SimProc::parseMessage (const char *preamble,
 		       const char *format,
-			...)
+		       va_list  args)
 {
   char     mess[MAX_PARSER_ERR_SIZE];
-  va_list  args;
 
   // Construct the message
-  va_start (args, format);
   snprintf (mess, MAX_PARSER_ERR_SIZE, format, args);
 
   cerr << lineNumber << ": " << preamble << mess << endl;

--- a/src/SimProc.cpp
+++ b/src/SimProc.cpp
@@ -1416,9 +1416,6 @@ SimProc::parseMessage (const char *preamble,
 void
 SimProc::scan ()
 {
-  //! The most recent word read in.
-  char  word[LEXEME_MAX];
-
   // Get the next word from the input
   readWord ();
 

--- a/src/SimProc.cpp
+++ b/src/SimProc.cpp
@@ -1876,8 +1876,7 @@ SimProc::readChar ()
       ch     = nextCh;			// We had an unreadch
       nextCh = -1;
     }
-
-  if (fh->get (c))
+  else if (fh->get (c))
     {
       ch = c;				// Char to int
     }
@@ -1895,7 +1894,7 @@ SimProc::readChar ()
 //-----------------------------------------------------------------------------
 //! Revert the next character to be analysed.
 
-//! Cannot affect the line number count.
+//! Can affect the line number count.
 
 //! @note This can only be called once between calls to readChar (). It is an
 //!       error if readChar () has yet to be called (when ::prevCh will be -1).

--- a/src/SimProc.h
+++ b/src/SimProc.h
@@ -177,7 +177,7 @@ private:
 		    ...);
   void  parseMessage (const char *preamble,
 		      const char *format,
-		      ...);
+		      va_list args);
 
   // Scanner (lexical analyser) for the processor description
   void  scan ();


### PR DESCRIPTION
- Fix offset by 1 bug in SimProc::isValidReg
- Remove the unused word local variable in SimProc::scan
- Shouldn't eat the unget char in SimProc::readChar 
- Clear prevCh to -1 in SimProc::unreadChar 
- Correct parseMessage prototype(... to va_list args)
- Fix typo of base in SimProc::extractNumberLval